### PR TITLE
split with newline on long output

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -13,6 +13,7 @@ description:
   zh_Hans: "支持线程回复（可选将首次回复发送至频道）、mrkdwn格式、引用线程历史和用户列表、并可选限制使用频道的Slack机器人插件。"
   pt_BR: "Plugin de bot do Slack para respostas em thread (opcionalmente postando a primeira resposta no canal), formatação mrkdwn, acesso ao histórico de thread e lista de usuários, e restrição opcional de canais de uso."
 icon: icon.svg
+tags: ['productivity','social']
 resource:
   memory: 536870912
   permission:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - `manifest.yaml` に新しいメタデータフィールド「tags」（"productivity" と "social"）が追加されました。

- **バグ修正**
  - Slackメッセージが3,000文字を超える場合、行をできるだけ分割せずに複数メッセージへ分割するよう改善されました。長い行も適切に分割されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->