### PR TITLE
Dify呼び出しのタイムアウト時のエラーメッセージのスキップオプションを追加

### DIFF
--- a/group/slack.yaml
+++ b/group/slack.yaml
@@ -30,6 +30,15 @@ settings:
       pt_BR: Permitir Retentativas
       ja_JP: 再試行を許可
     default: false
+  - name: skip_timeout_error
+    type: boolean
+    required: false
+    label:
+      en_US: Skip App Timeout Error Notifications
+      zh_Hans: 跳过应用程序超时错误通知
+      pt_BR: Pular Notificações de Erro de Timeout do Aplicativo
+      ja_JP: アプリのタイムアウトエラー通知をスキップ
+    default: false
   - name: allowed_channel
     type: text-input
     required: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - Slack連携設定に「skip_timeout_error」オプションを追加しました。これにより、アプリケーションのタイムアウトエラー通知をスキップできるようになりました。

- **バグ修正**
  - Slackメンションイベント処理時のエラーハンドリングが改善され、より分かりやすいエラーメッセージが表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->