### PR TITLE
Prune stale threads' cache from Dify Plugin's Persistent Storage

### DIFF
--- a/endpoints/slack.py
+++ b/endpoints/slack.py
@@ -212,7 +212,11 @@ class SlackEndpoint(Endpoint):
             data["messages"] = messages
             data["last_cleanup"] = now
             try:
-                self.session.storage.set(key, json.dumps(data).encode("utf-8"))
+                if not messages:
+                    # メッセージが空ならキー自体を削除
+                    self.session.storage.delete(key)
+                else:
+                    self.session.storage.set(key, json.dumps(data).encode("utf-8"))
             except Exception:
                 pass
         return messages


### PR DESCRIPTION
Added logic to prune stale threads' cache from Dify Plugin's Persistent Storage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 有効期限切れメッセージのフィルタリング後、キャッシュ内にメッセージが残っていない場合はキャッシュが削除されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->